### PR TITLE
Vulnerability fix

### DIFF
--- a/src/PolyLend.sol
+++ b/src/PolyLend.sol
@@ -426,13 +426,13 @@ contract PolyLend is PolyLendEE, ERC1155TokenReceiver {
             revert AuctionHasNotEnded();
         }
 
+        // cancel the loan
+        loans[_loanId].borrower = address(0);
+
         // transfer the borrower's collateral to the lender
         conditionalTokens.safeTransferFrom(
             address(this), msg.sender, loans[_loanId].positionId, loans[_loanId].collateralAmount, ""
         );
-
-        // cancel the loan
-        loans[_loanId].borrower = address(0);
 
         emit LoanReclaimed(_loanId);
     }


### PR DESCRIPTION
Fixed the reentrancy vulnerability described in https://github.com/Polymarket/PolyLend/issues/23

Fixed by setting `loans[_loanId].borrower` to `address(0)` before transferring collateral to the lender.